### PR TITLE
feat(worker): add alternative rsync host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Steps (as root):
 3. `cd /buildroots/buildit && ciel new`, making sure to create an instance named "main" when asked
 4. `echo 'nspawn-extra-options = ["-E", "NO_COLOR=1"]' >> .ciel/data/config.toml` to disable colored logging
 5. `cp /buildroots/buildit/buildit/systemd/buildit-worker.service /etc/systemd/system`
-6. `$EDITOR /etc/systemd/system/buildit-worker.service`：update ARCH, BUILDIT_AMQP_ADDR and BUILDIT_SSH_KEY
+6. `$EDITOR /etc/systemd/system/buildit-worker.service`：update ARCH, BUILDIT_AMQP_ADDR and BUILDIT_SSH_KEY; for workers in China, optionally update BUILDIT_RSYNC_HOST to repo-cn.aosc.io
 7. `systemctl enable --now buildit-worker`
 8. `chmod 600 /etc/systemd/system/buildit-worker.service`
 9. Setup SSH key of AOSC Maintainers at the location of BUILDIT_SSH_KEY

--- a/systemd/buildit-worker.service
+++ b/systemd/buildit-worker.service
@@ -8,7 +8,7 @@ Restart=always
 RestartSec=30
 ExecStart=cargo run --bin worker -- --ciel-path /buildroots/buildit --arch ARCH
 WorkingDirectory=/buildroots/buildit/buildit
-Environment=RUST_LOG=info BUILDIT_AMQP_ADDR=REDACTED BUILDIT_SSH_KEY=REDACTED
+Environment=RUST_LOG=info BUILDIT_AMQP_ADDR=REDACTED BUILDIT_SSH_KEY=REDACTED BUILDIT_RSYNC_HOST=repo.aosc.io
 
 [Install]
 WantedBy=multi-user.target

--- a/worker/src/build.rs
+++ b/worker/src/build.rs
@@ -171,7 +171,14 @@ async fn build(job: &Job, tree_path: &Path, args: &Args) -> anyhow::Result<JobRe
             if failed_package.is_none() {
                 let output = get_output_logged(
                     "pushpkg",
-                    &["-i", &args.upload_ssh_key, "maintainers", &job.git_ref],
+                    &[
+                        "--host",
+                        &args.rsync_host,
+                        "-i",
+                        &args.upload_ssh_key,
+                        "maintainers",
+                        &job.git_ref
+                    ],
                     &output_path,
                     &mut logs,
                 )

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -67,4 +67,13 @@ pub struct Args {
     /// SSH key for repo uploading
     #[arg(short = 's', long, env = "BUILDIT_SSH_KEY")]
     pub upload_ssh_key: String,
+
+    /// rsync host (server)
+    #[arg(
+        short,
+        long,
+        default_value = "repo.aosc.io",
+        env = "BUILDIT_RSYNC_HOST"
+    )]
+    pub rsync_host: String,
 }


### PR DESCRIPTION
- Require pushpkg 0+git20240120 or later versions.