### PR TITLE
fix: remove short flag for pushpkg_options, avoiding conflict with wo…

### DIFF
--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -49,7 +49,6 @@ pub struct Args {
 
     /// pushpkg extra options
     #[arg(
-        short,
         long,
         default_value = "",
         env = "BUILDIT_PUSHPKG_OPTIONS"


### PR DESCRIPTION
…rker_performance

Hot fix for...
```
thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.11/src/builder/debug_asserts.rs:112:17:
Command worker: Short option names must be unique for each argument, but '-p' is in use by both 'pushpkg_options' and 'worker_performance'
```

The short flag was never in use.