### PR TITLE
fix: keep '-' and '_' unescaped in PRs

### DIFF
--- a/buildit-utils/src/github.rs
+++ b/buildit-utils/src/github.rs
@@ -261,7 +261,7 @@ fn escape(text: &str) -> String {
     for char in text.chars() {
         if matches!(
             char,
-            '*' | '~' | '`' | '[' | ']' | '(' | ')' | '_' | '-' | '\\'
+            '*' | '~' | '`' | '[' | ']' | '(' | ')' | '\\'
         ) {
             result.push('\\');
         }


### PR DESCRIPTION
The Markdown parser of GitHub seems to follow the CommonMark specification (partially). Per spec 0.31.2, example 20, escape cannot be used in autolinks. If we have a '-' escaped as '\\-' in a URL in our commit message, it will not be recognized as a escape sequence.

What is out of CommonMark is that GitHub also recognize plain links ('https://xxx'), which are not even CommonMark autolinks ('\<https://xxx>'), as autolinks.

These two characters are common in URLs, they have to be used twice ('\-\-') to have a styling semantic in Markdown texts, in the common case they are used only once when used in package versions. Based on these three reasons, I suggest removing them from the list.

Other escaped characters are also affected by the parser behavior, but they are more common in our commit messages, less common in URLs, and characters like '\~' and '\*' will have styling semantic even when there is only a single symbol. Based on these, they are not removed.

Reported-by: Mingcong Bai <jeffbai@aosc.io>
Fixes: f2d87dbb1ddb ("fix: escape commit messages in openpr")
Link: https://spec.commonmark.org/0.31.2/#backslash-escapes
