### PR TITLE
feat: add checklists for the PR template

### DIFF
--- a/buildit-utils/src/github.rs
+++ b/buildit-utils/src/github.rs
@@ -24,7 +24,7 @@ use crate::{
 
 macro_rules! PR {
     () => {
-        "Topic Description\n-----------------\n\n{}\n\nPackage(s) Affected\n-------------------\n\n{}\n\nSecurity Update?\n----------------\n\nNo\n\nBuild Order\n-----------\n\n```\n{}\n```\n\nTest Build(s) Done\n------------------\n\n{}"
+        include_str!("template.md")
     };
 }
 

--- a/buildit-utils/src/template.md
+++ b/buildit-utils/src/template.md
@@ -1,0 +1,32 @@
+Topic Description
+-----------------
+
+{}
+
+Package(s) Affected
+-------------------
+
+{}
+
+Build Order
+-----------
+
+```
+{}
+```
+
+Test Build(s) Done
+------------------
+
+{}
+
+Pre-Approve Checks
+------------------
+
+- [ ] conflicts with other topics have been negotiated or don't exist (ask aosc.io/contact if unsure)
+- [ ] commits abide by [the styling manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/#git-commit-messages)
+- [ ] scripting changes abide by [the styling manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/)
+- [ ] dickens report exists
+  - [ ] no breaking changes (e.g., sover) or has rebuilt broken reverse dependencies
+  - [ ] no unexpected file changes (e.g., permission, massive file addition or removal)
+- [ ] at least one primary architecture has been tested LGTM


### PR DESCRIPTION
- define a core set of checks to do before approving a given PR.
- use the include_str macro for the PR macro
- remove the Security Update section
  - it isn't used by actual security update PRs.