### PR TITLE
feat(server): implement global feed endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,6 +4376,7 @@ dependencies = [
  "text-splitter",
  "timeago",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",
@@ -5009,6 +5010,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,7 +13,7 @@ common = { path = "../common" }
 dotenvy = "0.15.7"
 octocrab = "0.49"
 once_cell = "1.21.4"
-reqwest = { version = "0.13", default-features = false, features = ["multipart", "query", "charset", "http2", "system-proxy", "rustls-no-provider"] }
+reqwest = { version = "0.13", default-features = false, features = ["multipart", "query", "charset", "http2", "system-proxy", "rustls-no-provider", "json"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 teloxide = { version = "0.17", features = ["macros"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -39,3 +39,4 @@ hyper = "1.8.1"
 tower = "0.5"
 futures = "0.3.32"
 text-splitter = "0.29"
+tokio-stream = { version = "0.1.18", default-features = false, features = ["sync"] }

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -1,5 +1,6 @@
 use crate::{
     ARGS, DbPool,
+    feed::{EventContent, deliver_feed_event},
     github::{get_crab_github_installation, get_packages_from_pr},
     models::{Job, NewJob, NewPipeline, Pipeline, User, Worker},
 };
@@ -481,6 +482,11 @@ pub async fn job_restart(pool: DbPool, job_id: i32) -> anyhow::Result<Job> {
     match job_restart_in_transaction(job_id, &mut conn).await {
         Ok(new_job) => {
             PoolTransactionManager::<AnsiTransactionManager>::commit_transaction(&mut conn)?;
+            deliver_feed_event(EventContent::JobRestarted {
+                pipeline_id: new_job.pipeline_id,
+                old_job_id: job_id,
+                new_job_id: new_job.id,
+            });
             return Ok(new_job);
         }
         Err(err) => {

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -3,6 +3,7 @@ use crate::{
     feed::{EventContent, deliver_feed_event},
     github::{get_crab_github_installation, get_packages_from_pr},
     models::{Job, NewJob, NewPipeline, Pipeline, User, Worker},
+    routes::{PipelineInfoRequest, query_pipeline_info},
 };
 use anyhow::Context;
 use anyhow::{anyhow, bail};
@@ -248,6 +249,20 @@ pub async fn pipeline_new(
                 .get_result(&mut conn)
                 .context("Failed to create job")?,
         );
+    }
+
+    drop(conn);
+    // deliver feed event
+    {
+        let pipeline_info = query_pipeline_info(
+            PipelineInfoRequest {
+                pipeline_id: pipeline.id,
+            },
+            &pool,
+        )
+        .await
+        .context("Failed to load pipeline info")?;
+        deliver_feed_event(EventContent::PipelineCreated(Box::new(pipeline_info)));
     }
 
     Ok((pipeline, jobs))

--- a/server/src/feed.rs
+++ b/server/src/feed.rs
@@ -1,0 +1,98 @@
+use std::sync::{Arc, OnceLock};
+
+use serde::Serialize;
+use tokio::sync::broadcast;
+
+use crate::routes::{JobInfoResponse, PipelineInfoResponse};
+
+pub static FEED_TX: OnceLock<broadcast::Sender<Arc<FeedEvent>>> = OnceLock::new();
+
+pub fn deliver_feed_event(content: EventContent) {
+    let event = FeedEvent::new(content);
+    // The only possible error is "no subscribers", which can be safely ignored.
+    _ = FEED_TX.get().unwrap().send(Arc::new(event));
+}
+
+pub fn deliver_feed_events<I: IntoIterator<Item = EventContent>>(contents: I) {
+    let tx = FEED_TX.get().unwrap();
+    for content in contents.into_iter() {
+        let event = FeedEvent::new(content);
+        if tx.send(Arc::new(event)).is_err() {
+            // The only possible error is "no subscribers",
+            // in which future events can be skipped
+            break;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FeedEvent {
+    pub id: u64,
+    pub content: EventContent,
+}
+
+impl FeedEvent {
+    pub fn new_lagged() -> Self {
+        Self::new(EventContent::FeedLagged)
+    }
+
+    pub fn new(content: EventContent) -> Self {
+        Self {
+            id: Self::generate_id(),
+            content,
+        }
+    }
+
+    fn generate_id() -> u64 {
+        rand::random()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventContent {
+    FeedLagged,
+    PipelineCreated(Box<PipelineInfoResponse>),
+    JobRestarted {
+        pipeline_id: i32,
+        old_job_id: i32,
+        new_job_id: i32,
+    },
+    JobCompleted(Box<JobInfoResponse>),
+    JobAssigned(Box<JobAssignmentUpdate>),
+    JobUnassigned(Box<JobAssignmentUpdate>),
+}
+
+impl EventContent {
+    pub fn is_related_to_pipeline(&self, id: i32) -> bool {
+        match self {
+            EventContent::FeedLagged => false,
+            EventContent::PipelineCreated(resp) => resp.pipeline_id == id,
+            EventContent::JobRestarted { pipeline_id, .. } => *pipeline_id == id,
+            EventContent::JobCompleted(resp) => resp.pipeline_id == id,
+            EventContent::JobAssigned(update) => update.pipeline_id == id,
+            EventContent::JobUnassigned(update) => update.pipeline_id == id,
+        }
+    }
+
+    pub fn is_related_to_job(&self, id: i32) -> bool {
+        match self {
+            EventContent::FeedLagged => false,
+            EventContent::PipelineCreated(_) => false,
+            EventContent::JobRestarted { old_job_id, .. } => *old_job_id == id,
+            EventContent::JobCompleted(resp) => resp.job_id == id,
+            EventContent::JobAssigned(update) => update.job_id == id,
+            EventContent::JobUnassigned(update) => update.job_id == id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JobAssignmentUpdate {
+    pub pipeline_id: i32,
+    pub job_id: i32,
+    pub arch: String,
+    pub worker_id: i32,
+    pub worker_name: String,
+    pub worker_arch: String,
+}

--- a/server/src/formatter.rs
+++ b/server/src/formatter.rs
@@ -173,7 +173,7 @@ pub fn to_html_build_result(
         job.arch,
         rendered_all_pkgs,
         rendered_succeeded_pkgs,
-        &failed_package.clone().unwrap_or(String::from("None")),
+        failed_package.clone().unwrap_or(String::from("None")),
         rendered_skipped_pkgs,
         if let Some(log) = log_url {
             Cow::Owned(format!("<a href=\"{}\">Build Log >></a>", log))

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -12,6 +12,7 @@ use tokio::net::{TcpListener, UnixListener, unix::UCred};
 
 pub mod api;
 pub mod bot;
+pub mod feed;
 pub mod formatter;
 pub mod github;
 pub mod models;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -124,6 +124,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/ws/worker/{hostname}", get(ws_worker_handler))
         .route("/api/webhook", post(webhook_handler))
         .route("/api/user/self", get(user_self))
+        .route("/api/feed", get(sse_global_feed_handler))
         .nest_service("/assets", ServeDir::new("frontend/dist/assets"))
         .route_service("/favicon.ico", ServeFile::new("frontend/dist/favicon.ico"))
         .route_service("/robots.txt", ServeFile::new("frontend/dist/robots.txt"))

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use axum::extract::MatchedPath;
 use axum::http::Method;
 use axum::routing::post;
@@ -8,6 +9,7 @@ use diesel::r2d2::Pool;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_otlp::WithExportConfig;
 use server::bot::{Command, answer, answer_callback};
+use server::feed::FEED_TX;
 use server::recycler::recycler_worker;
 use server::routes::*;
 use server::{ARGS, DbPool, RemoteAddr};
@@ -15,6 +17,7 @@ use std::collections::HashMap;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::Mutex;
 use teloxide::prelude::*;
+use tokio::sync::broadcast;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 use tracing::{info, info_span};
@@ -86,6 +89,11 @@ async fn main() -> anyhow::Result<()> {
     } else {
         None
     };
+
+    let (feed_tx, _) = broadcast::channel(128);
+    FEED_TX
+        .set(feed_tx)
+        .map_err(|_| anyhow!("feed tx init conflict"))?;
 
     tracing::info!("Starting http server");
     // build our application with a route

--- a/server/src/routes/job.rs
+++ b/server/src/routes/job.rs
@@ -1,3 +1,4 @@
+use crate::DbPool;
 use crate::models::{Job, Pipeline, User, Worker};
 use crate::routes::{AnyhowError, AppState};
 use anyhow::Context;
@@ -106,17 +107,19 @@ pub async fn job_list(
 
 #[derive(Deserialize)]
 pub struct JobInfoRequest {
-    job_id: i32,
+    pub(crate) job_id: i32,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JobInfoResponse {
     // from job
-    job_id: i32,
-    pipeline_id: i32,
+    pub job_id: i32,
+    pub pipeline_id: i32,
     packages: String,
     arch: String,
     creation_time: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    creation_timestamp: chrono::DateTime<chrono::Utc>,
     status: String,
     build_success: Option<bool>,
     pushpkg_success: Option<bool>,
@@ -125,6 +128,8 @@ pub struct JobInfoResponse {
     skipped_packages: Option<String>,
     log_url: Option<String>,
     finish_time: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(with = "chrono::serde::ts_seconds_option")]
+    finish_timestamp: Option<chrono::DateTime<chrono::Utc>>,
     error_message: Option<String>,
     elapsed_secs: Option<i64>,
     assigned_worker_id: Option<i32>,
@@ -134,6 +139,8 @@ pub struct JobInfoResponse {
     require_min_total_mem_per_core: Option<f32>,
     require_min_disk: Option<i64>,
     assign_time: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(with = "chrono::serde::ts_seconds_option")]
+    assign_timestamp: Option<chrono::DateTime<chrono::Utc>>,
 
     // from pipeline
     git_branch: String,
@@ -145,73 +152,85 @@ pub struct JobInfoResponse {
     built_by_worker_hostname: Option<String>,
 }
 
-pub async fn job_info(
-    Query(query): Query<JobInfoRequest>,
-    State(AppState { pool, .. }): State<AppState>,
-) -> Result<Json<JobInfoResponse>, AnyhowError> {
+pub async fn query_job_info(
+    req: JobInfoRequest,
+    pool: &DbPool,
+) -> Result<JobInfoResponse, anyhow::Error> {
     let mut conn = pool
         .get()
         .context("Failed to get db connection from pool")?;
 
-    Ok(Json(
-        conn.transaction::<JobInfoResponse, diesel::result::Error, _>(|conn| {
-            // use alias to allow joining workers table twice
-            // https://github.com/diesel-rs/diesel/issues/2569
-            // https://github.com/diesel-rs/diesel/pull/2254
-            // https://docs.rs/diesel/latest/diesel/macro.alias.html
-            let assigned_workers = diesel::alias!(crate::schema::workers as assigned_workers);
-            let (job, pipeline, assigned_worker, built_by_worker) = crate::schema::jobs::dsl::jobs
-                .find(query.job_id)
-                .inner_join(crate::schema::pipelines::dsl::pipelines)
-                .left_join(
-                    assigned_workers.on(crate::schema::jobs::dsl::assigned_worker_id.eq(
-                        assigned_workers
-                            .field(crate::schema::workers::dsl::id)
-                            .nullable(),
-                    )),
-                )
-                .left_join(
-                    crate::schema::workers::dsl::workers
-                        .on(crate::schema::jobs::dsl::built_by_worker_id
-                            .eq(crate::schema::workers::dsl::id.nullable())),
-                )
-                .get_result::<(Job, Pipeline, Option<Worker>, Option<Worker>)>(conn)?;
+    conn.transaction::<JobInfoResponse, diesel::result::Error, _>(|conn| {
+        // use alias to allow joining workers table twice
+        // https://github.com/diesel-rs/diesel/issues/2569
+        // https://github.com/diesel-rs/diesel/pull/2254
+        // https://docs.rs/diesel/latest/diesel/macro.alias.html
+        let assigned_workers = diesel::alias!(crate::schema::workers as assigned_workers);
+        let (job, pipeline, assigned_worker, built_by_worker) = crate::schema::jobs::dsl::jobs
+            .find(req.job_id)
+            .inner_join(crate::schema::pipelines::dsl::pipelines)
+            .left_join(
+                assigned_workers.on(crate::schema::jobs::dsl::assigned_worker_id.eq(
+                    assigned_workers
+                        .field(crate::schema::workers::dsl::id)
+                        .nullable(),
+                )),
+            )
+            .left_join(
+                crate::schema::workers::dsl::workers
+                    .on(crate::schema::jobs::dsl::built_by_worker_id
+                        .eq(crate::schema::workers::dsl::id.nullable())),
+            )
+            .get_result::<(Job, Pipeline, Option<Worker>, Option<Worker>)>(conn)?;
 
-            Ok(JobInfoResponse {
-                job_id: job.id,
-                pipeline_id: job.pipeline_id,
-                packages: job.packages,
-                arch: job.arch,
-                creation_time: job.creation_time,
-                status: job.status,
-                build_success: job.build_success,
-                pushpkg_success: job.pushpkg_success,
-                successful_packages: job.successful_packages,
-                failed_package: job.failed_package,
-                skipped_packages: job.skipped_packages,
-                log_url: job.log_url,
-                finish_time: job.finish_time,
-                error_message: job.error_message,
-                elapsed_secs: job.elapsed_secs,
-                assigned_worker_id: job.assigned_worker_id,
-                built_by_worker_id: job.built_by_worker_id,
-                require_min_core: job.require_min_core,
-                require_min_total_mem: job.require_min_total_mem,
-                require_min_total_mem_per_core: job.require_min_total_mem_per_core,
-                require_min_disk: job.require_min_disk,
-                assign_time: job.assign_time,
+        Ok(JobInfoResponse {
+            job_id: job.id,
+            pipeline_id: job.pipeline_id,
+            packages: job.packages,
+            arch: job.arch,
+            creation_time: job.creation_time,
+            creation_timestamp: job.creation_time,
+            status: job.status,
+            build_success: job.build_success,
+            pushpkg_success: job.pushpkg_success,
+            successful_packages: job.successful_packages,
+            failed_package: job.failed_package,
+            skipped_packages: job.skipped_packages,
+            log_url: job.log_url,
+            finish_time: job.finish_time,
+            finish_timestamp: job.finish_time,
+            error_message: job.error_message,
+            elapsed_secs: job.elapsed_secs,
+            assigned_worker_id: job.assigned_worker_id,
+            built_by_worker_id: job.built_by_worker_id,
+            require_min_core: job.require_min_core,
+            require_min_total_mem: job.require_min_total_mem,
+            require_min_total_mem_per_core: job.require_min_total_mem_per_core,
+            require_min_disk: job.require_min_disk,
+            assign_time: job.assign_time,
+            assign_timestamp: job.assign_time,
 
-                // from pipeline
-                git_branch: pipeline.git_branch,
-                git_sha: pipeline.git_sha,
-                github_pr: pipeline.github_pr,
+            // from pipeline
+            git_branch: pipeline.git_branch,
+            git_sha: pipeline.git_sha,
+            github_pr: pipeline.github_pr,
 
-                // from worker
-                assigned_worker_hostname: assigned_worker.map(|w| w.hostname),
-                built_by_worker_hostname: built_by_worker.map(|w| w.hostname),
-            })
-        })?,
-    ))
+            // from worker
+            assigned_worker_hostname: assigned_worker.map(|w| w.hostname),
+            built_by_worker_hostname: built_by_worker.map(|w| w.hostname),
+        })
+    })
+    .with_context(|| format!("load job info for {}", req.job_id))
+}
+
+pub async fn job_info(
+    Query(query): Query<JobInfoRequest>,
+    State(AppState { pool, .. }): State<AppState>,
+) -> Result<Json<JobInfoResponse>, AnyhowError> {
+    query_job_info(query, &pool)
+        .await
+        .map(Json)
+        .map_err(AnyhowError)
 }
 
 #[derive(Deserialize)]

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -23,6 +23,7 @@ use tracing::info;
 
 pub mod job;
 pub mod pipeline;
+pub mod sse;
 pub mod user;
 pub mod webhook;
 pub mod websocket;
@@ -30,6 +31,7 @@ pub mod worker;
 
 pub use job::*;
 pub use pipeline::*;
+pub use sse::*;
 pub use user::*;
 pub use webhook::*;
 pub use websocket::*;

--- a/server/src/routes/pipeline.rs
+++ b/server/src/routes/pipeline.rs
@@ -1,3 +1,4 @@
+use crate::DbPool;
 use crate::models::User;
 use crate::routes::{AnyhowError, ApiAuth, AppState};
 use crate::{
@@ -69,69 +70,81 @@ pub async fn pipeline_new_pr(
 
 #[derive(Deserialize)]
 pub struct PipelineInfoRequest {
-    pipeline_id: i32,
+    pub pipeline_id: i32,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct PipelineInfoResponseJob {
-    job_id: i32,
-    arch: String,
-    status: String,
+    pub job_id: i32,
+    pub arch: String,
+    pub status: String,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct PipelineInfoResponse {
     // from pipeline
-    pipeline_id: i32,
-    packages: String,
-    archs: String,
-    git_branch: String,
-    git_sha: String,
-    creation_time: chrono::DateTime<chrono::Utc>,
-    github_pr: Option<i64>,
+    pub pipeline_id: i32,
+    pub packages: String,
+    pub archs: String,
+    pub git_branch: String,
+    pub git_sha: String,
+    pub creation_time: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub creation_timestamp: chrono::DateTime<chrono::Utc>,
+    pub github_pr: Option<i64>,
 
     // related jobs
-    jobs: Vec<PipelineInfoResponseJob>,
+    pub jobs: Vec<PipelineInfoResponseJob>,
+}
+
+pub async fn query_pipeline_info(
+    req: PipelineInfoRequest,
+    pool: &DbPool,
+) -> Result<PipelineInfoResponse, anyhow::Error> {
+    let mut conn = pool
+        .get()
+        .context("Failed to get db connection from pool")?;
+
+    conn.transaction::<PipelineInfoResponse, diesel::result::Error, _>(|conn| {
+        let pipeline = crate::schema::pipelines::dsl::pipelines
+            .find(req.pipeline_id)
+            .get_result::<Pipeline>(conn)?;
+
+        let jobs: Vec<PipelineInfoResponseJob> = crate::schema::jobs::dsl::jobs
+            .filter(crate::schema::jobs::dsl::pipeline_id.eq(pipeline.id))
+            .order(crate::schema::jobs::dsl::id.asc())
+            .load::<Job>(conn)?
+            .into_iter()
+            .map(|job| PipelineInfoResponseJob {
+                job_id: job.id,
+                arch: job.arch,
+                status: job.status,
+            })
+            .collect();
+
+        Ok(PipelineInfoResponse {
+            pipeline_id: pipeline.id,
+            packages: pipeline.packages,
+            archs: pipeline.archs,
+            git_branch: pipeline.git_branch,
+            git_sha: pipeline.git_sha,
+            creation_time: pipeline.creation_time,
+            creation_timestamp: pipeline.creation_time,
+            github_pr: pipeline.github_pr,
+            jobs,
+        })
+    })
+    .with_context(|| format!("load pipeline info for {}", req.pipeline_id))
 }
 
 pub async fn pipeline_info(
     Query(query): Query<PipelineInfoRequest>,
     State(AppState { pool, .. }): State<AppState>,
 ) -> Result<Json<PipelineInfoResponse>, AnyhowError> {
-    let mut conn = pool
-        .get()
-        .context("Failed to get db connection from pool")?;
-
-    Ok(Json(
-        conn.transaction::<PipelineInfoResponse, diesel::result::Error, _>(|conn| {
-            let pipeline = crate::schema::pipelines::dsl::pipelines
-                .find(query.pipeline_id)
-                .get_result::<Pipeline>(conn)?;
-
-            let jobs: Vec<PipelineInfoResponseJob> = crate::schema::jobs::dsl::jobs
-                .filter(crate::schema::jobs::dsl::pipeline_id.eq(pipeline.id))
-                .order(crate::schema::jobs::dsl::id.asc())
-                .load::<Job>(conn)?
-                .into_iter()
-                .map(|job| PipelineInfoResponseJob {
-                    job_id: job.id,
-                    arch: job.arch,
-                    status: job.status,
-                })
-                .collect();
-
-            Ok(PipelineInfoResponse {
-                pipeline_id: pipeline.id,
-                packages: pipeline.packages,
-                archs: pipeline.archs,
-                git_branch: pipeline.git_branch,
-                git_sha: pipeline.git_sha,
-                creation_time: pipeline.creation_time,
-                github_pr: pipeline.github_pr,
-                jobs,
-            })
-        })?,
-    ))
+    query_pipeline_info(query, &pool)
+        .await
+        .map(Json)
+        .map_err(AnyhowError)
 }
 
 #[derive(Deserialize)]

--- a/server/src/routes/sse.rs
+++ b/server/src/routes/sse.rs
@@ -1,0 +1,60 @@
+use crate::{
+    RemoteAddr,
+    feed::{EventContent, FEED_TX, FeedEvent},
+};
+use axum::{
+    extract::{ConnectInfo, Query},
+    response::{IntoResponse, Sse, sse},
+};
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio_stream::{StreamExt, wrappers::BroadcastStream};
+use tracing::info;
+
+#[derive(Deserialize)]
+pub struct GlobalFeedQuery {
+    #[serde(default)]
+    filter_pipeline: Option<i32>,
+    #[serde(default)]
+    filter_job: Option<i32>,
+}
+
+pub async fn sse_global_feed_handler(
+    Query(query): Query<GlobalFeedQuery>,
+    ConnectInfo(addr): ConnectInfo<RemoteAddr>,
+) -> impl IntoResponse {
+    info!("{:?} connected to global feed", addr);
+
+    let feed_rx = FEED_TX.get().unwrap().subscribe();
+    let feed_stream = BroadcastStream::new(feed_rx);
+    let sse_stream = feed_stream
+        .map(|event| event.unwrap_or_else(|_| Arc::new(FeedEvent::new_lagged())))
+        .filter(move |event| filter_feed_events(event, &query))
+        .map(serialize_feed_to_sse_event);
+    Sse::new(sse_stream).keep_alive(sse::KeepAlive::new())
+}
+
+fn serialize_feed_to_sse_event(event: Arc<FeedEvent>) -> Result<sse::Event, axum::Error> {
+    sse::Event::default()
+        .id(event.id.to_string())
+        .json_data(&event.content)
+}
+
+fn filter_feed_events(event: &FeedEvent, query: &GlobalFeedQuery) -> bool {
+    if matches!(event.content, EventContent::FeedLagged) {
+        // always deliver lag notification
+        return true;
+    }
+    if let Some(filter_pipeline) = query.filter_pipeline
+        && !event.content.is_related_to_pipeline(filter_pipeline)
+    {
+        return false;
+    }
+    if let Some(filter_job) = query.filter_job
+        && !event.content.is_related_to_job(filter_job)
+    {
+        return false;
+    }
+
+    true
+}

--- a/server/src/routes/worker.rs
+++ b/server/src/routes/worker.rs
@@ -1,5 +1,6 @@
 use crate::HEARTBEAT_TIMEOUT;
-use crate::routes::{AnyhowError, AppState};
+use crate::feed::{EventContent, JobAssignmentUpdate, deliver_feed_event, deliver_feed_events};
+use crate::routes::{AnyhowError, AppState, JobInfoRequest, query_job_info};
 use crate::{
     ARGS,
     api::{self},
@@ -362,7 +363,7 @@ pub async fn worker_job_update(
     }
 
     use crate::schema::jobs::dsl::*;
-    match payload.result {
+    match &payload.result {
         JobResult::Ok(res) => {
             diesel::update(jobs.filter(id.eq(payload.job_id)))
                 .set((
@@ -374,9 +375,9 @@ pub async fn worker_job_update(
                     build_success.eq(res.build_success),
                     pushpkg_success.eq(res.pushpkg_success),
                     successful_packages.eq(res.successful_packages.join(",")),
-                    failed_package.eq(res.failed_package),
+                    failed_package.eq(&res.failed_package),
                     skipped_packages.eq(res.skipped_packages.join(",")),
-                    log_url.eq(res.log_url),
+                    log_url.eq(&res.log_url),
                     finish_time.eq(chrono::Utc::now()),
                     elapsed_secs.eq(res.elapsed_secs),
                     assigned_worker_id.eq(None::<i32>),
@@ -394,6 +395,21 @@ pub async fn worker_job_update(
                 .execute(&mut conn)?;
         }
     }
+
+    drop(conn);
+    // deliver feed event
+    {
+        let job_info = query_job_info(
+            JobInfoRequest {
+                job_id: payload.job_id,
+            },
+            &pool,
+        )
+        .await
+        .context("Failed to load job info")?;
+        deliver_feed_event(EventContent::JobCompleted(Box::new(job_info)));
+    }
+
     Ok(())
 }
 

--- a/server/src/routes/worker.rs
+++ b/server/src/routes/worker.rs
@@ -199,6 +199,8 @@ pub async fn worker_poll(
         .get()
         .context("Failed to get db connection from pool")?;
 
+    let mut feed_events: Vec<EventContent> = Vec::new();
+
     match conn.transaction::<Option<(Pipeline, Job)>, diesel::result::Error, _>(|conn| {
         use crate::schema::jobs::dsl::*;
 
@@ -209,9 +211,19 @@ pub async fn worker_poll(
             .first::<Worker>(conn)?;
 
         // remove if any job is already allocated to the worker
-        diesel::update(jobs.filter(assigned_worker_id.eq(worker.id)))
+        let unassigned_jobs = diesel::update(jobs.filter(assigned_worker_id.eq(worker.id)))
             .set((status.eq("created"), assigned_worker_id.eq(None::<i32>)))
-            .execute(conn)?;
+            .get_results::<Job>(conn)?;
+        for unassigned_job in unassigned_jobs {
+            feed_events.push(EventContent::JobUnassigned(Box::new(JobAssignmentUpdate {
+                pipeline_id: unassigned_job.pipeline_id,
+                job_id: unassigned_job.id,
+                arch: unassigned_job.arch,
+                worker_id: worker.id,
+                worker_name: worker.hostname.clone(),
+                worker_arch: worker.arch.clone(),
+            })));
+        }
 
         // prioritize jobs on stable branch
         let mut sql = jobs
@@ -270,12 +282,23 @@ pub async fn worker_poll(
                     ))
                     .execute(conn)?;
 
+                feed_events.push(EventContent::JobAssigned(Box::new(JobAssignmentUpdate {
+                    pipeline_id: pipeline.id,
+                    job_id: job.id,
+                    arch: job.arch.clone(),
+                    worker_id: worker.id,
+                    worker_name: worker.hostname,
+                    worker_arch: worker.arch,
+                })));
+
                 Ok(Some((pipeline, job)))
             }
             None => Ok(None),
         }
     })? {
         Some((pipeline, job)) => {
+            deliver_feed_events(feed_events);
+
             // update github check run status to in-progress
             if let Some(github_check_run_id) = job.github_check_run_id {
                 tokio::spawn(async move {


### PR DESCRIPTION
This PR implements a `/api/feed` endpoint which allows clients to subscribe to server activities through SSE.

This makes creating alternative bot implementation (e.g. IRC bot) easier.