### PR TITLE
Failarch fixup 20260719

### DIFF
--- a/buildit-utils/src/github.rs
+++ b/buildit-utils/src/github.rs
@@ -1131,6 +1131,9 @@ fn test_auto_add_label() {
     );
 }
 
+// Contains "prperly" formatted test cases.
+// Just ignore the long lines ...
+#[rustfmt::skip]
 #[test]
 fn test_failarch() -> anyhow::Result<()> {
     let exprs = [
@@ -1148,114 +1151,25 @@ fn test_failarch() -> anyhow::Result<()> {
     let test_cases = [
         // Index, arch, buildable?
         (0, vec!["loongson3"], false),
-        (
-            0,
-            vec![
-                "amd64",
-                "arm64",
-                "loongarch64",
-                "ppc64el",
-                "riscv64",
-                "i486",
-            ],
-            true,
-        ),
+        (0, vec!["amd64", "arm64", "loongarch64", "ppc64el", "riscv64", "i486"], true),
         (1, vec!["loongarch64", "loongson3", "riscv64"], false),
         (1, vec!["amd64", "arm64", "ppc64el", "i486"], true),
-        (
-            2,
-            vec![
-                "amd64",
-                "arm64",
-                "ppc64el",
-                "loongarch64",
-                "loongson3",
-                "riscv64",
-            ],
-            false,
-        ),
+        (2, vec!["amd64", "arm64", "ppc64el", "loongarch64", "loongson3", "riscv64"], false),
         (2, vec!["i486"], true),
         (3, vec!["amd64"], false),
-        (
-            3,
-            vec![
-                "arm64",
-                "loongarch64",
-                "loongson3",
-                "ppc64el",
-                "riscv64",
-                "i486",
-            ],
-            true,
-        ),
-        (
-            4,
-            vec![
-                "amd64",
-                "arm64",
-                "loongarch64",
-                "loongson3",
-                "ppc64el",
-                "riscv64",
-            ],
-            false,
-        ),
+        (3, vec!["arm64", "loongarch64", "loongson3", "ppc64el", "riscv64", "i486"], true),
+        (4, vec!["amd64", "arm64", "loongarch64", "loongson3", "ppc64el", "riscv64"], false),
         (4, vec!["i486"], true),
         (5, vec!["amd64", "arm64", "loongarch64"], true),
         (5, vec!["loongson3", "ppc64el", "riscv64", "i486"], false),
-        (
-            6,
-            vec![
-                "amd64",
-                "arm64",
-                "loongarch64",
-                "loongson3",
-                "ppc64el",
-                "riscv64",
-            ],
-            true,
-        ),
+        (6, vec!["amd64", "arm64", "loongarch64", "loongson3", "ppc64el", "riscv64"], true),
         (6, vec!["i486"], false),
-        (
-            7,
-            vec![
-                "amd64",
-                "arm64",
-                "loongarch64",
-                "loongson3",
-                "ppc64el",
-                "riscv64",
-                "i486",
-            ],
-            true,
-        ),
+        (7, vec!["amd64", "arm64", "loongarch64", "loongson3", "ppc64el", "riscv64", "i486"], true),
         (7, vec!["armv7hf"], false),
-        (
-            8,
-            vec![
-                "amd64",
-                "arm64",
-                "loongarch64",
-                "loongson3",
-                "ppc64el",
-                "riscv64",
-            ],
-            true,
-        ),
+        (8, vec!["amd64", "arm64", "loongarch64", "loongson3", "ppc64el", "riscv64"], true),
         (8, vec!["i486", "armv7hf"], false),
         (9, vec!["i486", "armv7hf"], true),
-        (
-            9,
-            vec![
-                "amd64",
-                "arm64",
-                "loongarch64",
-                "loongson3",
-                "ppc64el",
-                "riscv64",
-            ],
-            false,
-        ),
+        (9, vec!["amd64", "arm64", "loongarch64", "loongson3", "ppc64el", "riscv64"], false),
     ];
     for (case_idx, (idx, arches, result)) in test_cases.into_iter().enumerate() {
         eprintln!("Case {}:", case_idx + 1);

--- a/buildit-utils/src/github.rs
+++ b/buildit-utils/src/github.rs
@@ -35,6 +35,7 @@ pub enum FailArchExpr {
     Include(Vec<String>),
     /// !(amd64|arm64)
     Exclude(Vec<String>),
+    Empty,
 }
 
 struct OpenPR<'a> {
@@ -754,7 +755,7 @@ fn get_archgroups() -> anyhow::Result<ABArchGroupMap> {
 #[tracing::instrument(skip(p))]
 pub fn get_archs<'a>(p: &'a Path, packages: &'a [String]) -> anyhow::Result<Vec<&'static str>> {
     let mut is_noarch = vec![];
-    let mut failarch_expr = String::new();
+    let mut failarch_exprs = vec![];
 
     for_each_abbs(p, |pkg, path| {
         if !packages.contains(&pkg.to_string()) {
@@ -777,23 +778,27 @@ pub fn get_archs<'a>(p: &'a Path, packages: &'a [String]) -> anyhow::Result<Vec<
                 );
 
                 if let Some(fail_arch) = defines.get("FAIL_ARCH") {
-                    failarch_expr = fail_arch.clone();
-                };
+                    failarch_exprs.push(fail_arch.clone());
+                } else {
+                    failarch_exprs.push(String::new());
+                }
             }
         }
     });
 
     if is_noarch.is_empty() || is_noarch.iter().any(|x| !x) {
-        if failarch_expr.is_empty() {
+        if failarch_exprs.is_empty() {
             return Ok(ALL_ARCH.iter().map(|x| x.to_owned()).collect());
         }
         // FAIL_ARCH is defined. Check if any of ALL_ARCH is buildable.
         let archgroup_map = get_archgroups()?;
         let mut allowed = vec![];
-        let parsed_expr = parse_fail_arch(&failarch_expr)?;
-        for a in ALL_ARCH {
-            if buildable(a, &parsed_expr, &archgroup_map) {
-                allowed.push(a.to_owned());
+        for expr in failarch_exprs {
+            let parsed_expr = parse_fail_arch(&expr)?;
+            for a in ALL_ARCH {
+                if buildable(a, &parsed_expr, &archgroup_map) && !allowed.contains(a) {
+                    allowed.push(a.to_owned());
+                }
             }
         }
         Ok(allowed)
@@ -866,6 +871,9 @@ pub fn for_each_abbs<F: FnMut(&str, &Path)>(path: &Path, mut f: F) {
 }
 
 pub fn parse_fail_arch(expr: &str) -> anyhow::Result<FailArchExpr> {
+    if expr.trim().is_empty() {
+        return Ok(FailArchExpr::Empty)
+    }
     let mut vec = Vec::new();
     // Valid architecture name.
     let re_valid_arch = Regex::new("^[0-9a-z_]+$")?;
@@ -900,6 +908,7 @@ pub fn buildable(arch: &str, cond: &FailArchExpr, archgroup_map: &ABArchGroupMap
     let entries = match cond {
         FailArchExpr::Exclude(v) => v,
         FailArchExpr::Include(v) => v,
+        FailArchExpr::Empty => return true,
     };
     let mut matches = false;
     for entry in entries {
@@ -918,6 +927,7 @@ pub fn buildable(arch: &str, cond: &FailArchExpr, archgroup_map: &ABArchGroupMap
     match cond {
         FailArchExpr::Exclude(_) => matches,
         FailArchExpr::Include(_) => !matches,
+        FailArchExpr::Empty => true,
     }
 }
 

--- a/buildit-utils/src/github.rs
+++ b/buildit-utils/src/github.rs
@@ -18,8 +18,8 @@ use tracing::{Instrument, debug, error, info, info_span, warn};
 use walkdir::WalkDir;
 
 use crate::{
-    ABArchGroupMap, ABBS_REPO_LOCK, ALL_ARCH, AMD64, ARM64, COMMITS_COUNT_LIMIT, LOONGARCH64,
-    LOONGARCH64_NOSIMD, LOONGSON3, NOARCH, PPC64EL, RISCV64,
+    ABArchGroupMap, ABBS_REPO_LOCK, ALL_ARCH, AMD64, ARM64, COMMITS_COUNT_LIMIT, I486,
+    LOONGARCH64, LOONGARCH64_NOSIMD, LOONGSON3, NOARCH, PPC64EL, RISCV64,
 };
 
 const ARCHGROUP_DATA: &str = "/usr/lib/autobuild4/sets/arch_groups.json";
@@ -668,6 +668,7 @@ fn format_archs(archs: &[&str]) -> String {
     map.insert("loongson3", LOONGSON3);
     map.insert("ppc64el", PPC64EL);
     map.insert("riscv64", RISCV64);
+    map.insert("i486", I486);
 
     let mut newline = false;
 
@@ -708,6 +709,19 @@ fn format_archs(archs: &[&str]) -> String {
         }
     }
 
+    // Afterglow
+    if archs.contains(&"i486") {
+        if newline {
+            s.push('\n');
+        }
+        s.push_str("**Afterglow Architectures**\n\n");
+    }
+
+    for i in ["i486"] {
+        if archs.contains(&i) {
+            s.push_str(&format!("- [ ] {}\n", map[i]));
+        }
+    }
     s
 }
 

--- a/buildit-utils/src/github.rs
+++ b/buildit-utils/src/github.rs
@@ -780,7 +780,7 @@ pub fn get_archs<'a>(p: &'a Path, packages: &'a [String]) -> anyhow::Result<Vec<
                 if let Some(fail_arch) = defines.get("FAIL_ARCH") {
                     failarch_exprs.push(fail_arch.clone());
                 } else {
-                    failarch_exprs.push(String::new());
+                    failarch_exprs.push("!(mainline)".into());
                 }
             }
         }

--- a/buildit-utils/src/lib.rs
+++ b/buildit-utils/src/lib.rs
@@ -43,7 +43,7 @@ pub const ALL_ARCH: &[&str] = &[
     "riscv64",
     // Retro architectures:
     // NOTE: only available architectures should be added!
-    // "i486"
+    "i486"
 ];
 
 pub static ABBS_REPO_LOCK: Lazy<tokio::sync::Mutex<()>> = Lazy::new(|| tokio::sync::Mutex::new(()));

--- a/buildit-utils/src/lib.rs
+++ b/buildit-utils/src/lib.rs
@@ -32,7 +32,7 @@ pub const PPC64EL: &str = "PowerPC 64-bit (Little Endian) `ppc64el`";
 pub const RISCV64: &str = "RISC-V 64-bit `riscv64`";
 pub const COMMITS_COUNT_LIMIT: usize = 10;
 
-pub const ALL_ARCH: &[&str] = &[
+pub const MAINLINE_ARCH: &[&str] = &[
     // Mainline architectures:
     "amd64",
     "arm64",
@@ -41,9 +41,21 @@ pub const ALL_ARCH: &[&str] = &[
     "loongson3",
     "ppc64el",
     "riscv64",
-    // Retro architectures:
-    // NOTE: only available architectures should be added!
-    "i486"
+];
+
+pub const RETRO_ARCH: &[&str] = &[
+    "i486",
+];
+
+pub const ALL_ARCH: &[&str] = &[
+    "amd64",
+    "arm64",
+    "loongarch64",
+    "loongarch64_nosimd",
+    "loongson3",
+    "ppc64el",
+    "riscv64",
+    "i486",
 ];
 
 pub static ABBS_REPO_LOCK: Lazy<tokio::sync::Mutex<()>> = Lazy::new(|| tokio::sync::Mutex::new(()));

--- a/buildit-utils/src/lib.rs
+++ b/buildit-utils/src/lib.rs
@@ -41,7 +41,6 @@ pub const ALL_ARCH: &[&str] = &[
     "loongson3",
     "ppc64el",
     "riscv64",
-
     // Retro architectures:
     // NOTE: only available architectures should be added!
     // "i486"

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -119,6 +119,7 @@
       archs: [
         "amd64",
         "arm64",
+	"i486",
         "loongarch64",
         "loongarch64_nosimd",
         "loongson3",

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -6,8 +6,7 @@ use crate::{
 use anyhow::Context;
 use anyhow::{anyhow, bail};
 use buildit_utils::{
-    ABBS_REPO_LOCK, ALL_ARCH,
-    github::{get_archs, get_environment_requirement, resolve_packages, update_abbs},
+    ABBS_REPO_LOCK, ALL_ARCH, MAINLINE_ARCH, RETRO_ARCH, github::{get_archs, get_environment_requirement, resolve_packages, update_abbs},
 };
 use diesel::r2d2::PoolTransactionManager;
 use diesel::{
@@ -73,8 +72,13 @@ pub async fn pipeline_new(
     }
     if archs.contains(&"mainline") {
         // archs
-        archs.extend(ALL_ARCH.iter());
+        archs.extend(MAINLINE_ARCH.iter());
         archs.retain(|arch| *arch != "mainline");
+    }
+    if archs.contains(&"retro") || archs.contains(&"afterglow") {
+        // archs
+        archs.extend(RETRO_ARCH.iter());
+        archs.retain(|arch| *arch != "retro");
     }
     for arch in &archs {
         if !ALL_ARCH.contains(arch) && arch != &"noarch" {

--- a/server/src/bot.rs
+++ b/server/src/bot.rs
@@ -7,7 +7,7 @@ use crate::{
     paste_to_aosc_io,
 };
 use anyhow::{Context, anyhow, bail};
-use buildit_utils::{ALL_ARCH, find_update_and_update_checksum, github::OpenPRRequest};
+use buildit_utils::{ALL_ARCH, MAINLINE_ARCH, RETRO_ARCH, find_update_and_update_checksum, github::OpenPRRequest};
 use chrono::Local;
 use diesel::{Connection, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
 use rand::{distr::SampleString, rng, seq::IndexedRandom};
@@ -112,8 +112,13 @@ fn handle_archs_args(archs: Vec<&str>) -> Vec<&str> {
     let mut archs = archs;
     if archs.contains(&"mainline") {
         // archs
-        archs.extend(ALL_ARCH.iter());
+        archs.extend(MAINLINE_ARCH.iter());
         archs.retain(|arch| *arch != "mainline");
+    }
+    if archs.contains(&"retro") || archs.contains(&"afterglow") {
+        // archs
+        archs.extend(RETRO_ARCH.iter());
+        archs.retain(|arch| *arch != "retro");
     }
     archs.sort();
     archs.dedup();

--- a/server/src/routes/worker.rs
+++ b/server/src/routes/worker.rs
@@ -10,7 +10,7 @@ use crate::{
 use anyhow::Context;
 use anyhow::anyhow;
 use axum::extract::{Json, Query, State};
-use buildit_utils::{AMD64, ARM64, LOONGARCH64_NOSIMD, LOONGSON3, PPC64EL, RISCV64};
+use buildit_utils::{AMD64, ARM64, I486, LOONGARCH64_NOSIMD, LOONGSON3, PPC64EL, RISCV64};
 use buildit_utils::{LOONGARCH64, NOARCH};
 
 use chrono::{DateTime, Utc};
@@ -557,6 +557,7 @@ pub async fn handle_success_message(
                     "noarch" => NOARCH,
                     "amd64" => AMD64,
                     "arm64" => ARM64,
+		    "i486" => I486,
                     "loongson3" => LOONGSON3,
                     "ppc64el" => PPC64EL,
                     "riscv64" => RISCV64,


### PR DESCRIPTION
- Take the union instead of the intersection of the buildable architectures. (Actually it was taking the FAIL_ARCH expression from the last package in the queue.)
- Properly format the test cases.