### PR TITLE
feat(github.rs): add "survey" label when PR title contains "survey"

### DIFF
--- a/buildit-utils/src/github.rs
+++ b/buildit-utils/src/github.rs
@@ -630,6 +630,7 @@ fn auto_add_label(title: &str) -> Vec<String> {
             vec![String::from("has-fix"), String::from("ftbfs")],
         ),
         ("rework", vec![String::from("rework")]),
+        ("survey", vec![String::from("survey")]),
     ];
 
     for (k, v) in v {


### PR DESCRIPTION
As titled, this PR adds a rule to `auto_add_label` to automatically add the GitHub label ["survey"](https://github.com/AOSC-Dev/aosc-os-abbs/issues?q=sort%3Aupdated-desc+zotero+label%3Asurvey) when the title contains such a keyword.