### PR TITLE
feat: add status filters and improve paging on list pages

### DIFF
--- a/frontend/src/pages/jobs/index.vue
+++ b/frontend/src/pages/jobs/index.vue
@@ -2,6 +2,33 @@
   <v-container>
     <v-row>
       <v-col>
+        <v-expansion-panels>
+          <v-expansion-panel title="Jobs">
+            <v-expansion-panel-text>
+              <v-container class="pa-0">
+                <v-row class="pa-0">
+                  <v-col class="pa-0">
+                    <v-select
+                      v-model="statuses"
+                      :items="statusItems"
+                      label="Status"
+                      multiple
+                      chips
+                      closable-chips
+                      density="compact"
+                      :hide-details="true"
+                      @update:model-value="onFilterChange">
+                    </v-select>
+                  </v-col>
+                </v-row>
+              </v-container>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
         <v-data-table-server
           v-model:page="page"
           v-model:items-per-page="itemsPerPage"
@@ -210,25 +237,45 @@
   }
 
   export default {
-    data: () => ({
-      page: 1,
-      itemsPerPage: 100,
-      headers: [
-        { title: 'Status', key: 'status', sortable: false },
-        { title: 'Job', key: 'job', sortable: false },
-        { title: 'Pipeline', key: 'pipeline', sortable: false },
-        { title: 'Actions', key: 'actions', sortable: false },
-      ],
-      loading: true,
-      totalItems: 0,
-      serverItems: [],
-      jobRestartSnackbar: false,
-      newJobID: 0,
-    }),
+    data() {
+      return {
+        page: Number(this.$route.query.page) || 1,
+        itemsPerPage: Number(this.$route.query.items_per_page) || 100,
+        statuses: (this.$route.query.status as string)?.split(',').filter(s => s) || [],
+        statusItems: [
+          { title: 'Created', value: 'created' },
+          { title: 'Running', value: 'running' },
+          { title: 'Passed', value: 'success' },
+          { title: 'Failed', value: 'failed' },
+          { title: 'Error', value: 'error' },
+        ],
+        headers: [
+          { title: 'Status', key: 'status', sortable: false },
+          { title: 'Job', key: 'job', sortable: false },
+          { title: 'Pipeline', key: 'pipeline', sortable: false },
+          { title: 'Actions', key: 'actions', sortable: false },
+        ],
+        loading: true,
+        totalItems: 0,
+        serverItems: [],
+        jobRestartSnackbar: false,
+        newJobID: 0,
+      };
+    },
     methods: {
+      onFilterChange() {
+        this.page = 1;
+        this.loadItems();
+      },
       async loadItems () {
+        this.$router.push({path: this.$route.path, query: {
+          page: String(this.page),
+          items_per_page: String(this.itemsPerPage),
+          status: this.statuses.join(',')
+        } });
+
         this.loading = true;
-        let url = hostname + `/api/job/list?page=${this.page}&items_per_page=${this.itemsPerPage}`;
+        let url = hostname + `/api/job/list?page=${this.page}&items_per_page=${this.itemsPerPage}&status=${this.statuses.join(',')}`;
         let data = (await axios.get(url)).data;
         this.totalItems = data.total_items;
         this.serverItems = data.items;

--- a/frontend/src/pages/pipelines/index.vue
+++ b/frontend/src/pages/pipelines/index.vue
@@ -11,7 +11,7 @@
                     <v-checkbox
                       v-model="stableOnly"
                       label="Stable Branch Only"
-                      @update:model-value="loadItems"
+                      @update:model-value="onFilterChange"
                       :hide-details="true">
                     </v-checkbox>
                   </v-col>
@@ -19,9 +19,22 @@
                     <v-checkbox
                       v-model="githubPROnly"
                       label="GitHub PR Only"
-                      @update:model-value="loadItems"
+                      @update:model-value="onFilterChange"
                       :hide-details="true">
                     </v-checkbox>
+                  </v-col>
+                  <v-col class="pa-0">
+                    <v-select
+                      v-model="statuses"
+                      :items="statusItems"
+                      label="Status"
+                      multiple
+                      chips
+                      closable-chips
+                      density="compact"
+                      :hide-details="true"
+                      @update:model-value="onFilterChange">
+                    </v-select>
                   </v-col>
                   <v-col class="pa-0">
                     <v-checkbox
@@ -213,6 +226,13 @@
         itemsPerPage: Number(this.$route.query.items_per_page) || 100,
         stableOnly: this.$route.query.stable_only === "true",
         githubPROnly: this.$route.query.github_pr_only === "true",
+        statuses: (this.$route.query.status as string)?.split(',').filter(s => s) || [],
+        statusItems: [
+          { title: 'Passed', value: 'success' },
+          { title: 'Failed', value: 'failed' },
+          { title: 'Running', value: 'running' },
+          { title: 'Error', value: 'error' },
+        ],
         headers: [
           { title: 'Status', key: 'status', sortable: false },
           { title: 'Pipeline', key: 'pipeline', sortable: false },
@@ -241,11 +261,16 @@
           items_per_page: String(this.itemsPerPage),
           stable_only: String(this.stableOnly),
           github_pr_only: String(this.githubPROnly),
+          status: this.statuses.join(','),
           auto_refresh: String(this.autoRefresh)
         } });
       }
     },
     methods: {
+      onFilterChange() {
+        this.page = 1;
+        this.loadItems();
+      },
       startAutoRefresh() {
         this.countdown = 30;
         this.intervalHandle = setInterval(() => {
@@ -264,11 +289,12 @@
           items_per_page: String(this.itemsPerPage),
           stable_only: String(this.stableOnly),
           github_pr_only: String(this.githubPROnly),
+          status: this.statuses.join(','),
           auto_refresh: String(this.autoRefresh)
         } });
 
         this.loading = true;
-        let data = (await axios.get(hostname + `/api/pipeline/list?page=${this.page}&items_per_page=${this.itemsPerPage}&stable_only=${this.stableOnly}&github_pr_only=${this.githubPROnly}`)).data;
+        let data = (await axios.get(hostname + `/api/pipeline/list?page=${this.page}&items_per_page=${this.itemsPerPage}&stable_only=${this.stableOnly}&github_pr_only=${this.githubPROnly}&status=${this.statuses.join(',')}`)).data;
         this.totalItems = data.total_items;
         this.serverItems = data.items;
         this.loading = false;

--- a/frontend/src/pages/workers/index.vue
+++ b/frontend/src/pages/workers/index.vue
@@ -2,14 +2,39 @@
   <v-container>
     <v-row>
       <v-col>
-        <v-data-table-server
-          :items-per-page="itemsPerPage"
+        <v-expansion-panels>
+          <v-expansion-panel title="Workers">
+            <v-expansion-panel-text>
+              <v-container class="pa-0">
+                <v-row class="pa-0">
+                  <v-col class="pa-0">
+                    <v-select
+                      v-model="statuses"
+                      :items="statusItems"
+                      label="Status"
+                      multiple
+                      chips
+                      closable-chips
+                      density="compact"
+                      :hide-details="true">
+                    </v-select>
+                  </v-col>
+                </v-row>
+              </v-container>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        <v-data-table
+          :items-per-page="-1"
           :headers="headers"
-          :items="serverItems"
-          :items-length="totalItems"
+          :items="filteredItems"
           :loading="loading"
           item-value="id"
-          @update:options="loadItems">
+          hide-default-footer>
           <template #item.hostname="{ item }">
             <router-link :to="{ path: `/workers/${(item as Worker).id}` }">
               {{ (item as Worker).hostname }}
@@ -55,7 +80,7 @@
               <router-link :to="{ path: `/jobs/${(item as Worker).running_job_id}` }">
                 # {{ (item as Worker).running_job_id }}
               </router-link>
-              {{ 
+              {{
                 (item as Worker).running_job_assign_time !== null && (item as Worker).running_job_assign_time !== undefined ?
                   " since " + new TimeAgo('en-US').format(new Date((item as Worker).running_job_assign_time)) : ""
               }}
@@ -64,7 +89,7 @@
               No internet connectivity
             </div>
           </template>
-        </v-data-table-server>
+        </v-data-table>
       </v-col>
     </v-row>
   </v-container>
@@ -83,11 +108,6 @@
 
   TimeAgo.addDefaultLocale(en)
 
-  interface LoadItemsOpts {
-    page: number;
-    itemsPerPage: number;
-  }
-
   interface Worker {
     id: number;
     hostname: string;
@@ -102,26 +122,53 @@
   }
 
   export default {
-    data: () => ({
-      itemsPerPage: 50,
-      headers: [
-        { title: 'Hostname', key: 'hostname', sortable: false },
-        { title: 'Architecture', key: 'arch', sortable: false },
-        { title: 'Logical Cores', key: 'logical_cores', sortable: false },
-        { title: 'Memory Size', key: 'memory_bytes', sortable: false, value: (item: any) => prettyBytes(item.memory_bytes, { binary: true }) },
-        { title: 'Memory Per Core', key: 'memory_per_core', sortable: false, value: (item: any) => prettyBytes(item.memory_bytes / item.logical_cores, { binary: true }) },
-        { title: 'Disk Free Space Size', key: 'disk_free_space_bytes', sortable: false, value: (item: any) => prettyBytes(item.disk_free_space_bytes) },
-        { title: 'Status', key: 'status', sortable: false },
-      ],
-      loading: true,
-      totalItems: 0,
-      serverItems: []
-    }),
+    data() {
+      return {
+        statuses: [] as string[],
+        statusItems: [
+          { title: 'Live', value: 'live' },
+          { title: 'Dead', value: 'dead' },
+          { title: 'Idle', value: 'idle' },
+          { title: 'Busy', value: 'busy' },
+        ],
+        headers: [
+          { title: 'Hostname', key: 'hostname', sortable: false },
+          { title: 'Architecture', key: 'arch', sortable: false },
+          { title: 'Logical Cores', key: 'logical_cores', sortable: false },
+          { title: 'Memory Size', key: 'memory_bytes', sortable: false, value: (item: any) => prettyBytes(item.memory_bytes, { binary: true }) },
+          { title: 'Memory Per Core', key: 'memory_per_core', sortable: false, value: (item: any) => prettyBytes(item.memory_bytes / item.logical_cores, { binary: true }) },
+          { title: 'Disk Free Space Size', key: 'disk_free_space_bytes', sortable: false, value: (item: any) => prettyBytes(item.disk_free_space_bytes) },
+          { title: 'Status', key: 'status', sortable: false },
+        ],
+        loading: true,
+        serverItems: [] as Worker[]
+      };
+    },
+    computed: {
+      filteredItems(): Worker[] {
+        if (this.statuses.length === 0) {
+          return this.serverItems;
+        }
+        return this.serverItems.filter((worker: Worker) => {
+          const status = this.workerStatus(worker);
+          // "live" matches any live worker, whether idle or busy
+          return this.statuses.includes(status) || (this.statuses.includes('live') && status !== 'dead');
+        });
+      }
+    },
+    mounted() {
+      this.loadItems();
+    },
     methods: {
-      async loadItems (opts: LoadItemsOpts) {
+      workerStatus(worker: Worker): string {
+        if (!worker.is_live) {
+          return 'dead';
+        }
+        return worker.running_job_id !== null && worker.running_job_id !== undefined ? 'busy' : 'idle';
+      },
+      async loadItems () {
         this.loading = true;
-        let data = (await axios.get(hostname + `/api/worker/list?page=${opts.page}&items_per_page=${opts.itemsPerPage}`)).data;
-        this.totalItems = data.total_items;
+        let data = (await axios.get(hostname + `/api/worker/list?page=1&items_per_page=-1`)).data;
         this.serverItems = data.items;
         this.loading = false;
       }

--- a/server/src/routes/job.rs
+++ b/server/src/routes/job.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 pub struct JobListRequest {
     page: i64,
     items_per_page: i64,
+    // comma-separated status values; empty means no status filter
+    #[serde(default)]
+    status: String,
 }
 
 #[derive(Serialize)]
@@ -51,16 +54,32 @@ pub async fn job_list(
 
     Ok(Json(
         conn.transaction::<JobListResponse, anyhow::Error, _>(|conn| {
-            let total_items = crate::schema::jobs::dsl::jobs.count().get_result(conn)?;
+            let statuses: Vec<&str> = query
+                .status
+                .split(',')
+                .filter(|status| !status.is_empty())
+                .collect();
 
-            let sql = crate::schema::jobs::dsl::jobs
+            let mut total_items_query = crate::schema::jobs::dsl::jobs.into_boxed();
+            if !statuses.is_empty() {
+                total_items_query =
+                    total_items_query.filter(crate::schema::jobs::dsl::status.eq_any(&statuses));
+            }
+            let total_items = total_items_query.count().get_result(conn)?;
+
+            let mut sql = crate::schema::jobs::dsl::jobs
                 .inner_join(crate::schema::pipelines::dsl::pipelines)
                 .left_join(
                     crate::schema::users::dsl::users
                         .on(crate::schema::pipelines::dsl::creator_user_id
                             .eq(crate::schema::users::dsl::id.nullable())),
                 )
-                .order(crate::schema::jobs::dsl::id.desc());
+                .order(crate::schema::jobs::dsl::id.desc())
+                .into_boxed();
+
+            if !statuses.is_empty() {
+                sql = sql.filter(crate::schema::jobs::dsl::status.eq_any(&statuses));
+            }
 
             // all
             let res = if query.items_per_page == -1 {

--- a/server/src/routes/pipeline.rs
+++ b/server/src/routes/pipeline.rs
@@ -140,6 +140,9 @@ pub struct PipelineListRequest {
     items_per_page: i64,
     stable_only: bool,
     github_pr_only: bool,
+    // comma-separated status values; empty means no status filter
+    #[serde(default)]
+    status: String,
 }
 
 #[derive(Serialize)]
@@ -183,21 +186,12 @@ pub async fn pipeline_list(
 
     Ok(Json(
         conn.transaction::<PipelineListResponse, diesel::result::Error, _>(|conn| {
-            // compute total items for pagination
-            let mut total_items_query = crate::schema::pipelines::dsl::pipelines.into_boxed();
+            let statuses: Vec<&str> = query
+                .status
+                .split(',')
+                .filter(|status| !status.is_empty())
+                .collect();
 
-            if query.stable_only {
-                total_items_query = total_items_query
-                    .filter(crate::schema::pipelines::dsl::git_branch.eq("stable"));
-            }
-            if query.github_pr_only {
-                total_items_query = total_items_query
-                    .filter(crate::schema::pipelines::dsl::github_pr.is_not_null());
-            }
-
-            let total_items = total_items_query.count().get_result(conn)?;
-
-            // collect pipelines
             let mut sql = crate::schema::pipelines::dsl::pipelines
                 .left_join(crate::schema::users::dsl::users)
                 .order_by(crate::schema::pipelines::dsl::id.desc())
@@ -210,105 +204,163 @@ pub async fn pipeline_list(
                 sql = sql.filter(crate::schema::pipelines::dsl::github_pr.is_not_null());
             }
 
-            let res: Vec<(Pipeline, Option<User>)> = if query.items_per_page == -1 {
-                sql.load::<(Pipeline, Option<User>)>(conn)?
-            } else {
-                sql.offset((query.page - 1) * query.items_per_page)
-                    .limit(query.items_per_page)
-                    .load::<(Pipeline, Option<User>)>(conn)?
-            };
-            let (pipelines, users): (Vec<Pipeline>, Vec<Option<User>>) = res.into_iter().unzip();
+            if statuses.is_empty() {
+                // fast path: compute total items in SQL, page first, and only
+                // load jobs of the pipelines on this page
+                let mut total_items_query = crate::schema::pipelines::dsl::pipelines.into_boxed();
 
-            // get all jobs of these pipelines
-            // and group by pipeline later
-            // see https://diesel.rs/guides/relations.html
-            let jobs = Job::belonging_to(&pipelines)
-                .select(Job::as_select())
-                .order(crate::schema::jobs::dsl::id.desc())
-                .load(conn)?;
-
-            let mut items = vec![];
-            for ((mut jobs, pipeline), creator) in jobs
-                .grouped_by(&pipelines)
-                .into_iter()
-                .zip(pipelines)
-                .zip(users)
-            {
-                // Mimic gitlab behavior: for each arch, only keep the latest
-                // (with maximum id) job. The maximum id is listed first via
-                // `.order(crate::schema::jobs::dsl::id.desc())`. Then
-                // `dedup_by` removes all but the first of consecutive elements.
-                jobs.sort_by(|a, b| a.arch.cmp(&b.arch));
-                jobs.dedup_by(|a, b| a.arch.eq(&b.arch));
-
-                let mut has_error = false;
-                let mut has_failed = false;
-                let mut has_unfinished = false;
-                for job in &jobs {
-                    match job.status.as_str() {
-                        "error" => has_error = true,
-                        "success" => {
-                            // success
-                        }
-                        "failed" => {
-                            // failed
-                            has_failed = true;
-                        }
-                        "created" => {
-                            has_unfinished = true;
-                        }
-                        "running" => {
-                            has_unfinished = true;
-                        }
-                        _ => {
-                            error!("Got job with unknown status: {:?}", job);
-                        }
-                    }
+                if query.stable_only {
+                    total_items_query = total_items_query
+                        .filter(crate::schema::pipelines::dsl::git_branch.eq("stable"));
+                }
+                if query.github_pr_only {
+                    total_items_query = total_items_query
+                        .filter(crate::schema::pipelines::dsl::github_pr.is_not_null());
                 }
 
-                let status = if has_error {
-                    "error"
-                } else if has_failed {
-                    "failed"
-                } else if has_unfinished {
-                    "running"
+                let total_items = total_items_query.count().get_result(conn)?;
+
+                let res: Vec<(Pipeline, Option<User>)> = if query.items_per_page == -1 {
+                    sql.load::<(Pipeline, Option<User>)>(conn)?
                 } else {
-                    "success"
+                    sql.offset((query.page - 1) * query.items_per_page)
+                        .limit(query.items_per_page)
+                        .load::<(Pipeline, Option<User>)>(conn)?
+                };
+                let (pipelines, users): (Vec<Pipeline>, Vec<Option<User>>) =
+                    res.into_iter().unzip();
+
+                // get all jobs of these pipelines
+                // and group by pipeline later
+                // see https://diesel.rs/guides/relations.html
+                let jobs = Job::belonging_to(&pipelines)
+                    .select(Job::as_select())
+                    .order(crate::schema::jobs::dsl::id.desc())
+                    .load(conn)?;
+
+                let items = build_pipeline_list_items(pipelines, users, jobs);
+                Ok(PipelineListResponse { total_items, items })
+            } else {
+                // status filter path: a pipeline's status is computed from its
+                // latest job per arch (see below), so compute it for every
+                // candidate pipeline, then filter and page in memory
+                let res: Vec<(Pipeline, Option<User>)> = sql.load::<(Pipeline, Option<User>)>(conn)?;
+                let (pipelines, users): (Vec<Pipeline>, Vec<Option<User>>) =
+                    res.into_iter().unzip();
+
+                let jobs = Job::belonging_to(&pipelines)
+                    .select(Job::as_select())
+                    .order(crate::schema::jobs::dsl::id.desc())
+                    .load(conn)?;
+
+                let items: Vec<PipelineListResponseItem> =
+                    build_pipeline_list_items(pipelines, users, jobs)
+                        .into_iter()
+                        .filter(|item| statuses.contains(&item.status))
+                        .collect();
+
+                let total_items = items.len() as i64;
+                let items = if query.items_per_page == -1 {
+                    items
+                } else {
+                    items
+                        .into_iter()
+                        .skip(((query.page - 1) * query.items_per_page) as usize)
+                        .take(query.items_per_page as usize)
+                        .collect()
                 };
 
-                // compute pipeline status based on job status
-                items.push(PipelineListResponseItem {
-                    id: pipeline.id,
-                    git_branch: pipeline.git_branch,
-                    git_sha: pipeline.git_sha,
-                    packages: pipeline.packages,
-                    archs: pipeline.archs,
-                    creation_time: pipeline.creation_time,
-                    github_pr: pipeline.github_pr,
-                    status,
-
-                    creator_github_login: creator
-                        .as_ref()
-                        .and_then(|user| user.github_login.as_ref())
-                        .cloned(),
-                    creator_github_avatar_url: creator
-                        .as_ref()
-                        .and_then(|user| user.github_avatar_url.as_ref())
-                        .cloned(),
-                    jobs: jobs
-                        .into_iter()
-                        .map(|job| PipelineListResponseJob {
-                            job_id: job.id,
-                            arch: job.arch,
-                            status: job.status,
-                        })
-                        .collect(),
-                });
+                Ok(PipelineListResponse { total_items, items })
             }
-
-            Ok(PipelineListResponse { total_items, items })
         })?,
     ))
+}
+
+fn build_pipeline_list_items(
+    pipelines: Vec<Pipeline>,
+    users: Vec<Option<User>>,
+    jobs: Vec<Job>,
+) -> Vec<PipelineListResponseItem> {
+    let mut items = vec![];
+    for ((mut jobs, pipeline), creator) in jobs
+        .grouped_by(&pipelines)
+        .into_iter()
+        .zip(pipelines)
+        .zip(users)
+    {
+        // Mimic gitlab behavior: for each arch, only keep the latest
+        // (with maximum id) job. The maximum id is listed first via
+        // `.order(crate::schema::jobs::dsl::id.desc())`. Then
+        // `dedup_by` removes all but the first of consecutive elements.
+        jobs.sort_by(|a, b| a.arch.cmp(&b.arch));
+        jobs.dedup_by(|a, b| a.arch.eq(&b.arch));
+
+        let mut has_error = false;
+        let mut has_failed = false;
+        let mut has_unfinished = false;
+        for job in &jobs {
+            match job.status.as_str() {
+                "error" => has_error = true,
+                "success" => {
+                    // success
+                }
+                "failed" => {
+                    // failed
+                    has_failed = true;
+                }
+                "created" => {
+                    has_unfinished = true;
+                }
+                "running" => {
+                    has_unfinished = true;
+                }
+                _ => {
+                    error!("Got job with unknown status: {:?}", job);
+                }
+            }
+        }
+
+        let status = if has_error {
+            "error"
+        } else if has_failed {
+            "failed"
+        } else if has_unfinished {
+            "running"
+        } else {
+            "success"
+        };
+
+        // compute pipeline status based on job status
+        items.push(PipelineListResponseItem {
+            id: pipeline.id,
+            git_branch: pipeline.git_branch,
+            git_sha: pipeline.git_sha,
+            packages: pipeline.packages,
+            archs: pipeline.archs,
+            creation_time: pipeline.creation_time,
+            github_pr: pipeline.github_pr,
+            status,
+
+            creator_github_login: creator
+                .as_ref()
+                .and_then(|user| user.github_login.as_ref())
+                .cloned(),
+            creator_github_avatar_url: creator
+                .as_ref()
+                .and_then(|user| user.github_avatar_url.as_ref())
+                .cloned(),
+            jobs: jobs
+                .into_iter()
+                .map(|job| PipelineListResponseJob {
+                    job_id: job.id,
+                    arch: job.arch,
+                    status: job.status,
+                })
+                .collect(),
+        });
+    }
+
+    items
 }
 
 pub async fn pipeline_status(


### PR DESCRIPTION
## Summary

- Pipelines and jobs pages now support filtering by status, applied server-side through a new optional, comma-separated `status` parameter on `/api/pipeline/list` and `/api/job/list`. For jobs this is a plain SQL filter; for pipelines the filter is applied after status computation, since a pipeline's status is derived from its latest job per architecture (there is no `status` column on `pipelines`). The unfiltered path remains page-first.
- Jobs page now syncs page, page size, and active filters to the URL query, like the pipelines page already does; changing any filter resets the view to page 1 on all three list pages.
- Workers page no longer paginates: it loads all workers in a single request (`items_per_page=-1`) and filters client-side by Live / Dead / Idle / Busy (Live matches both Idle and Busy).

## Verification

- `yarn build` (`vue-tsc --noEmit` + `vite build`) passes.
- `cargo check` passes on Linux (run in WSL; the server uses `tokio::net::unix` and does not build on Windows). Note: requires `--ignore-rust-version` at the moment because the committed `Cargo.lock` pins `takecell 0.1.2`, which declares rustc 1.96 — a pre-existing lockfile/toolchain mismatch unrelated to this change.
- Not exercised against a live API (no local database/RabbitMQ available).

==================================

# AI Assistance Usage Declaration

This PR is authored with assistance from AI/LLM:

- Model: Kimi K3 (Moonshot AI)
- Platform: Moonshot AI (kimi.com)
- Agent platform: Kimi Code CLI
- Prompt:
```
The frontend now has very limited filtering and inconvenient paging for pipelines, jobs, and workers. There won't be many workers, so not paging the workers would be better. Also allow the user to filter pipelines, jobs, and workers, by status.
```
